### PR TITLE
fix package name from codegangsta/cli to /urfave/cli

### DIFF
--- a/golor.go
+++ b/golor.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
 	"math"


### PR DESCRIPTION
手元のPC(macOS 10.13.3, go1.9.2 darwin/amd64)で`go get github/khsk/golor`すると
golor.go:97:3: undefined: cli.ShowAppHelpAndExit
というエラーになってしまいました．github.com/codegangsta/cliは現在github.com/urfave/cliという名前になっているらしく，import文中の名前を変更すると正常にgo getできました．